### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2FAlmasB%2FFXGLGames&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
+
 This repo contains sample games built with <a href="https://github.com/AlmasB/FXGL">FXGL</a> Game Library.
 Each game focuses on one or two aspects of FXGL, e.g. Drop focuses on bare minimums, Pac-man focuses on AI, etc.
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1650)](https://user-images.githubusercontent.com/47092464/98444326-fa44aa80-214b-11eb-8d15-20b882a1e995.png)
