### PR TITLE
[fix version error] Bump client.plugin.version to 0.1.35

### DIFF
--- a/Drop/pom.xml
+++ b/Drop/pom.xml
@@ -18,7 +18,7 @@
 
         <fxgl.version>11.14</fxgl.version>
         <jfx.maven.plugin.version>0.0.4</jfx.maven.plugin.version>
-        <client.plugin.version>0.1.31-SNAPSHOT</client.plugin.version>
+        <client.plugin.version>0.1.35</client.plugin.version>
         <attach.version>4.0.8</attach.version>
         <mainClassName>com.almasb.fxglgames.drop.DropApp</mainClassName>
     </properties>


### PR DESCRIPTION
Since 0.1.31-SNAPSHOT version doesn't exists in the repo, the system would throw out errors