### PR TITLE
Append module name before main class e.g. <module-name>/<main-class>

### DIFF
--- a/GeometryWars/pom.xml
+++ b/GeometryWars/pom.xml
@@ -20,7 +20,7 @@
         <jfx.maven.plugin.version>0.0.5</jfx.maven.plugin.version>
         <client.plugin.version>0.1.35</client.plugin.version>
         <attach.version>4.0.9</attach.version>
-        <mainClassName>com.almasb.fxglgames.geowars.GeoWarsApp</mainClassName>
+        <mainClassName>geowars/com.almasb.fxglgames.geowars.GeoWarsApp</mainClassName>
     </properties>
 
     <dependencies>

--- a/GeometryWars/pom.xml
+++ b/GeometryWars/pom.xml
@@ -20,7 +20,7 @@
         <jfx.maven.plugin.version>0.0.5</jfx.maven.plugin.version>
         <client.plugin.version>0.1.35</client.plugin.version>
         <attach.version>4.0.9</attach.version>
-        <mainClassName>geowars/com.almasb.fxglgames.geowars.GeoWarsApp</mainClassName>
+        <mainClassName>com.almasb.fxglgames.geowars.GeoWarsApp</mainClassName>
     </properties>
 
     <dependencies>
@@ -122,7 +122,7 @@
                     <launcher>Start-game</launcher>
                     <jlinkImageName>game</jlinkImageName>
                     <jlinkZipName>spacewars-game-${project.version}</jlinkZipName>
-                    <mainClass>${mainClassName}</mainClass>
+                    <mainClass>geowars/${mainClassName}</mainClass>
                 </configuration>
             </plugin>
 

--- a/GeometryWars/src/main/java/module-info.java
+++ b/GeometryWars/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
  */
-open module geowars.main {
+open module geowars {
     requires com.almasb.fxgl.all;
 }


### PR DESCRIPTION
Because the whole project is modularized 
thus if we don't append module name before main class for the gluon plugin 
it will warn the developers that
```
Module name not found in <mainClass>. Module name will be assumed from module-info.java
```
So we add module name before main class to remove this warning
the whole java command is like 
```
java --module geowars/com.almasb.fxglgames.geowars.GeoWarsApp
```
and also may need to add module path
```
java --module-path . --module geowars/com.almasb.fxglgames.geowars.GeoWarsApp
```