### PR TITLE
Bump FXGL version from 17.3 to 21

### DIFF
--- a/Asteroids/pom.xml
+++ b/Asteroids/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.AsteroidsApp</mainClassName>
     </properties>
     

--- a/BattleTanks/pom.xml
+++ b/BattleTanks/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.tanks.BattleTanksApp</mainClassName>
     </properties>
 

--- a/Bomberman/pom.xml
+++ b/Bomberman/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.bomberman.BombermanApp</mainClassName>
     </properties>
 

--- a/Breakout/pom.xml
+++ b/Breakout/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
 
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
         <client.plugin.version>0.1.35</client.plugin.version>
         <attach.version>4.0.9</attach.version>

--- a/Cannon/pom.xml
+++ b/Cannon/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.cannon.CannonApp</mainClassName>
     </properties>
 

--- a/CrystalChase/pom.xml
+++ b/CrystalChase/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.cc.CrystalApp</mainClassName>
     </properties>
 

--- a/Drop/pom.xml
+++ b/Drop/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
 
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
         <client.plugin.version>0.1.35</client.plugin.version>
         <attach.version>4.0.9</attach.version>

--- a/FlappyBird/pom.xml
+++ b/FlappyBird/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.flappy.FlappyBirdApp</mainClassName>
     </properties>
 

--- a/GeoJumper/pom.xml
+++ b/GeoJumper/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <kotlin.version>1.4.30</kotlin.version>
         <mainClassName>com.almasb.fxglgames.geojumper.GeoJumperAppKt</mainClassName>
     </properties>

--- a/GeometryWars/pom.xml
+++ b/GeometryWars/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
 
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
         <gluonfx.plugin.version>1.0.7</gluonfx.plugin.version>
         <attach.version>4.0.9</attach.version>

--- a/Gravity/pom.xml
+++ b/Gravity/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.gravity.GravityApp</mainClassName>
     </properties>
 

--- a/KeyRain/pom.xml
+++ b/KeyRain/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.keyrain.KeyRainApp</mainClassName>
     </properties>
 

--- a/Mario/pom.xml
+++ b/Mario/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
 
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <jfx.maven.plugin.version>0.0.8</jfx.maven.plugin.version>
         <gluonfx.plugin.version>1.0.11</gluonfx.plugin.version>
         <attach.version>4.0.13</attach.version>

--- a/NinjaCardCombat/pom.xml
+++ b/NinjaCardCombat/pom.xml
@@ -20,7 +20,7 @@
         <kotlin.version>1.4.30</kotlin.version>
         <jackson.version>2.11.1</jackson.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.ncc.NCCApp</mainClassName>
     </properties>
 

--- a/OutRun/pom.xml
+++ b/OutRun/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <kotlin.version>1.4.30</kotlin.version>
         <mainClassName>com.almasb.fxglgames.outrun.OutRunAppKt</mainClassName>
     </properties>

--- a/Pacman/pom.xml
+++ b/Pacman/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.pacman.PacmanApp</mainClassName>
     </properties>
 

--- a/Pong/pom.xml
+++ b/Pong/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.pong.PongApp</mainClassName>
     </properties>
 

--- a/RTSGame/pom.xml
+++ b/RTSGame/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.rts.RTSApp</mainClassName>
     </properties>
 

--- a/Shooter/pom.xml
+++ b/Shooter/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.shooter.ShooterApp</mainClassName>
     </properties>
 

--- a/SlotMachine/pom.xml
+++ b/SlotMachine/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.slotmachine.SlotMachineApp</mainClassName>
     </properties>
 

--- a/SpaceInvaders/pom.xml
+++ b/SpaceInvaders/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.spaceinvaders.SpaceInvadersApp</mainClassName>
     </properties>
 

--- a/SpaceRanger/pom.xml
+++ b/SpaceRanger/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.spaceranger.SpaceRangerApp</mainClassName>
     </properties>
 

--- a/SpaceRunner/pom.xml
+++ b/SpaceRunner/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <mainClassName>com.almasb.fxglgames.spacerunner.SpaceRunnerApp</mainClassName>
     </properties>
 

--- a/TicTacToe/pom.xml
+++ b/TicTacToe/pom.xml
@@ -17,7 +17,7 @@
         <maven.shade.version>3.0.0</maven.shade.version>
 		<jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
 
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
 		
 		<mainClassName>com.almasb.fxglgames.tictactoe.TicTacToeApp</mainClassName>
     </properties>

--- a/TowerDefense/pom.xml
+++ b/TowerDefense/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.version>3.8.0</maven.compiler.version>
         <maven.shade.version>3.0.0</maven.shade.version>
 
-        <fxgl.version>17.3</fxgl.version>
+        <fxgl.version>21</fxgl.version>
         <jfx.maven.plugin.version>0.0.6</jfx.maven.plugin.version>
         <mainClassName>com.almasb.fxglgames.td.TowerDefenseApp</mainClassName>
     </properties>


### PR DESCRIPTION
The version < 21 on Mac will cause the application starting failed
so need to bump to the version 21 since its JavaFX dependency is 21.0.1 which fixed the error